### PR TITLE
Integración de fechas a cada signo

### DIFF
--- a/info/Taco por signo.txt
+++ b/info/Taco por signo.txt
@@ -1,79 +1,79 @@
-﻿* Cipactli – Cocodrilo (Caimán)
+﻿* Cipactli – Cocodrilo (Caimán) 4 - 23 Enero
 
 * Taco de Arrachera: Representa los comienzos, la fuerza y la abundancia. Como buen líder natural, este taco llega con todo el poder norteño y se impone en el asador desde el primer bocado.
 
-2. Ehecatl – Viento
+2. Ehecatl – Viento 24 enero - 12 febrero
 
 * Taco de Tripa: Adaptable, sociable y ligero, igual que el cotorreo en un puesto de tacos después de la fiesta del pueblo.
 
-3. Calli – Casa
+3. Calli – Casa 13 febrero - 4 marzo
 
 * Taco de Guisado Casero: Confortable, hogareño y estable, como los guisados de mamá un dominguito.
 
-4. Cuetzpalin – Lagarto
+4. Cuetzpalin – Lagarto 5 - 24 marzo
 
 * Taco Campechano: Siempre renovándose y ágil, combina carnes sin miedo al exito como buen mexicano, echándole limón y salsa verde.
 
-5. Coatl – Serpiente
+5. Coatl – Serpiente 25 marzo - 13 abril
 
 * Taco de Lengua: Misterioso y sorprendente, inicialmente intimida, pero conquista paladares valientes que se atreven a probar de todo.
 
-6. Miquiztli – Muerte
+6. Miquiztli – Muerte 14 abril - 3 mayo
 
 * Taco de Birria: La renovación hecha taco, ideal para curar la cruda más espantosa de los domingos en la mañana.
 
-7. Mazatl – Venado
+7. Mazatl – Venado 4 - 23 mayo
 
 * Taco de Cochinita Pibil: Refinado, estético y sensible, este taco es una joya del sureste que combina belleza con un sabor que hace llorar de emoción.
 
-8. Tochtli – Conejo
+8. Tochtli – Conejo 24 mayo - 12 junio
 
 * Taco al Pastor: Alegre y sociable, infalible para prender cualquier reunión, acompañado con su piña voladora.
 
-9. Atl – Agua
+9. Atl – Agua 13 junio - 2 julio
 
 * Taco de Pescado: Fluido, fresco y emocionalmente reconfortante, como un abrazo después de un mal día en la playa.
 
-10. Itzcuintli – Perro
+10. Itzcuintli – Perro  3 - 22 julio
 
 * Taco de Suadero: Leal, callejero y sabroso, el famoso "suaperro" es el favorito de los que saben que rollo en la taquería.
 
-11. Ozomahtli – Mono
+11. Ozomahtli – Mono  23 julio - 11 agosto
 
 * Taco de Canasta: Divertido y creativo, como el vendedor que pasa en bicicleta gritando "¡Tacos, tacos de canasta!".
 
-12. Malinalli – Hierba
+12. Malinalli – Hierba 12 - 31 agosto
 
 * Taco de Nopales: Equilibrado y prudente, listo para sanar cualquier malestar, ideal después de excesos culinarios.
 
-13. Acatl – Caña
+13. Acatl – Caña 1 - 20 septiembre
 
 * Taco Dorado: Firme y justo, como esos tacos doraditos bañados generosamente en salsita roja o verde.
 
-14. Ocelotl – Jaguar
+14. Ocelotl – Jaguar 21 septiembre - 10 octubre
 
 * Taco de Cecina: Decidido y magnético, conquista con fuerza y sabor tradicional mexicano.
 
-15. Cuauhtli – Águila
+15. Cuauhtli – Águila 11 - 30 octubre
 
 * Taco Gobernador: Ambicioso y estratégico, presente en los menús más selectos de México, conquistando alturas culinarias.
 
-16. Cozcacuauhtli – Buitre
+16. Cozcacuauhtli – Buitre 31 octubre - 19 noviembre
 
 * Taco de Carnitas: Sabio y transformador, como la comida del sábado con carnitas y una buena salsa verde con aguacate.
 
-17. Ollin – Movimiento
+17. Ollin – Movimiento  20 noviembre - 9 diciembre
 
 * Taco de Mixiote: Dinámico y activo, cambia y evoluciona, ideal para degustar en cualquier rincón mexicano.
 
-18. Tecpatl – Pedernal
+18. Tecpatl – Pedernal 10 - 20 diciembre
 
 * Taco de Chorizo: Valiente y desafiante, dispuesto a enfrentar cualquier reto con una buena salsa de habanero.
 
-19. Quiahuitl – Lluvia
+19. Quiahuitl – Lluvia Lluvia 30 diciembre - 18 enero
 
 * Taco Ahogado: Sensible y empático, perfecto para esos días lluviosos en Guadalajara con su buena salsa roja.
 
-20. Xochitl – Flor
+20. Xochitl – Flor 19 enero - 3 febrero
 
 * Taco de Barbacoa: Romántico y delicioso, ideal para comenzar el domingo con un toque de tradición y salsa borracha.


### PR DESCRIPTION
A cada signo se le agregó sus respectivas fechas, sin embargo debido al calendario que originalmente es de 260 dias al adaptarlo a nuestro calendario hay fechas/signos que se repiten